### PR TITLE
implement address and geohash labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/alexruf/tankerkoenig-go v1.0.0
+	github.com/mmcloughlin/geohash v0.9.0
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/common v0.7.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mmcloughlin/geohash v0.9.0 h1:FihR004p/aE1Sju6gcVq5OLDqGcMnpBY+8moBqIsVOs=
+github.com/mmcloughlin/geohash v0.9.0/go.mod h1:oNZxQo5yWJh0eMQEP/8hwQuVx9Z9tjwFUqcTB1SmG0c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/vendor/github.com/mmcloughlin/geohash/.appveyor.yml
+++ b/vendor/github.com/mmcloughlin/geohash/.appveyor.yml
@@ -1,0 +1,15 @@
+version: "{build}"
+
+clone_folder: c:\gopath\src\github.com\mmcloughlin\geohash
+
+environment:
+  GOPATH: c:\gopath
+
+install:
+  - echo %PATH%
+  - echo %GOPATH%
+  - go version
+  - go env
+
+build_script:
+  - go test -v

--- a/vendor/github.com/mmcloughlin/geohash/.gitignore
+++ b/vendor/github.com/mmcloughlin/geohash/.gitignore
@@ -1,0 +1,26 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+coverage.out

--- a/vendor/github.com/mmcloughlin/geohash/.travis.yml
+++ b/vendor/github.com/mmcloughlin/geohash/.travis.yml
@@ -1,0 +1,22 @@
+language: go
+go:
+- 1.x
+- 1.3.x
+- 1.4.x
+- 1.5.x
+- 1.6.x
+- 1.7.x
+- 1.8.x
+- 1.9.x
+- 1.10.x
+- 1.11.x
+before_install:
+- go get github.com/axw/gocov/gocov
+- go get github.com/mattn/goveralls
+- go get golang.org/x/tools/cmd/cover
+- go get github.com/klauspost/asmfmt/cmd/asmfmt
+script:
+- test -z "$(asmfmt -l *.s)"
+- go test -v -covermode=count -coverprofile=profile.cov
+after_success:
+- goveralls -coverprofile=profile.cov -service=travis-ci

--- a/vendor/github.com/mmcloughlin/geohash/LICENSE
+++ b/vendor/github.com/mmcloughlin/geohash/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Michael McLoughlin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/mmcloughlin/geohash/README.md
+++ b/vendor/github.com/mmcloughlin/geohash/README.md
@@ -1,0 +1,214 @@
+# geohash
+
+Go [geohash](https://en.wikipedia.org/wiki/Geohash) library offering encoding
+and decoding for string and integer geohashes.
+
+[![GoDoc Reference](http://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square)](http://godoc.org/github.com/mmcloughlin/geohash)
+[![Build status](https://img.shields.io/travis/mmcloughlin/geohash.svg?style=flat-square)](https://travis-ci.org/mmcloughlin/geohash)
+[![Coverage](https://img.shields.io/coveralls/mmcloughlin/geohash.svg?style=flat-square)](https://coveralls.io/r/mmcloughlin/geohash)
+[![Go Report Card](https://goreportcard.com/badge/github.com/mmcloughlin/geohash?style=flat-square)](https://goreportcard.com/report/github.com/mmcloughlin/geohash)
+
+## Install
+
+Fetch the package with
+
+```
+go get github.com/mmcloughlin/geohash
+```
+
+And import it into your programs with
+
+```go
+import "github.com/mmcloughlin/geohash"
+```
+
+## Usage
+
+#### func  Decode
+
+```go
+func Decode(hash string) (lat, lng float64)
+```
+Decode the string geohash to a (lat, lng) point.
+
+#### func  DecodeCenter
+
+```go
+func DecodeCenter(hash string) (lat, lng float64)
+```
+DecodeCenter decodes the string geohash to the central point of the bounding
+box.
+
+#### func  DecodeInt
+
+```go
+func DecodeInt(hash uint64) (lat, lng float64)
+```
+DecodeInt decodes the provided 64-bit integer geohash to a (lat, lng) point.
+
+#### func  DecodeIntWithPrecision
+
+```go
+func DecodeIntWithPrecision(hash uint64, bits uint) (lat, lng float64)
+```
+DecodeIntWithPrecision decodes the provided integer geohash with bits of
+precision to a (lat, lng) point.
+
+#### func  Encode
+
+```go
+func Encode(lat, lng float64) string
+```
+Encode the point (lat, lng) as a string geohash with the standard 12 characters
+of precision.
+
+#### func  EncodeInt
+
+```go
+func EncodeInt(lat, lng float64) uint64
+```
+EncodeInt encodes the point (lat, lng) to a 64-bit integer geohash.
+
+#### func  EncodeIntWithPrecision
+
+```go
+func EncodeIntWithPrecision(lat, lng float64, bits uint) uint64
+```
+EncodeIntWithPrecision encodes the point (lat, lng) to an integer with the
+specified number of bits.
+
+#### func  EncodeWithPrecision
+
+```go
+func EncodeWithPrecision(lat, lng float64, chars uint) string
+```
+EncodeWithPrecision encodes the point (lat, lng) as a string geohash with the
+specified number of characters of precision (max 12).
+
+#### func  Neighbor
+
+```go
+func Neighbor(hash string, direction Direction) string
+```
+Neighbor returns a geohash string that corresponds to the provided geohash's
+neighbor in the provided direction
+
+#### func  NeighborInt
+
+```go
+func NeighborInt(hash uint64, direction Direction) uint64
+```
+NeighborInt returns a uint64 that corresponds to the provided hash's neighbor in
+the provided direction at 64-bit precision.
+
+#### func  NeighborIntWithPrecision
+
+```go
+func NeighborIntWithPrecision(hash uint64, bits uint, direction Direction) uint64
+```
+NeighborIntWithPrecision returns a uint64s that corresponds to the provided
+hash's neighbor in the provided direction at the given precision.
+
+#### func  Neighbors
+
+```go
+func Neighbors(hash string) []string
+```
+Neighbors returns a slice of geohash strings that correspond to the provided
+geohash's neighbors.
+
+#### func  NeighborsInt
+
+```go
+func NeighborsInt(hash uint64) []uint64
+```
+NeighborsInt returns a slice of uint64s that correspond to the provided hash's
+neighbors at 64-bit precision.
+
+#### func  NeighborsIntWithPrecision
+
+```go
+func NeighborsIntWithPrecision(hash uint64, bits uint) []uint64
+```
+NeighborsIntWithPrecision returns a slice of uint64s that correspond to the
+provided hash's neighbors at the given precision.
+
+#### type Box
+
+```go
+type Box struct {
+	MinLat float64
+	MaxLat float64
+	MinLng float64
+	MaxLng float64
+}
+```
+
+Box represents a rectangle in latitude/longitude space.
+
+#### func  BoundingBox
+
+```go
+func BoundingBox(hash string) Box
+```
+BoundingBox returns the region encoded by the given string geohash.
+
+#### func  BoundingBoxInt
+
+```go
+func BoundingBoxInt(hash uint64) Box
+```
+BoundingBoxInt returns the region encoded by the given 64-bit integer geohash.
+
+#### func  BoundingBoxIntWithPrecision
+
+```go
+func BoundingBoxIntWithPrecision(hash uint64, bits uint) Box
+```
+BoundingBoxIntWithPrecision returns the region encoded by the integer geohash
+with the specified precision.
+
+#### func (Box) Center
+
+```go
+func (b Box) Center() (lat, lng float64)
+```
+Center returns the center of the box.
+
+#### func (Box) Contains
+
+```go
+func (b Box) Contains(lat, lng float64) bool
+```
+Contains decides whether (lat, lng) is contained in the box. The containment
+test is inclusive of the edges and corners.
+
+#### func (Box) Round
+
+```go
+func (b Box) Round() (lat, lng float64)
+```
+Round returns a point inside the box, making an effort to round to minimal
+precision.
+
+#### type Direction
+
+```go
+type Direction int
+```
+
+Direction represents directions in the latitute/longitude space.
+
+```go
+const (
+	North Direction = iota
+	NorthEast
+	East
+	SouthEast
+	South
+	SouthWest
+	West
+	NorthWest
+)
+```
+Cardinal and intercardinal directions

--- a/vendor/github.com/mmcloughlin/geohash/README.tmpl
+++ b/vendor/github.com/mmcloughlin/geohash/README.tmpl
@@ -1,0 +1,25 @@
+# geohash
+
+Go [geohash](https://en.wikipedia.org/wiki/Geohash) library offering encoding
+and decoding for string and integer geohashes.
+
+[![GoDoc Reference](http://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square)](http://godoc.org/github.com/mmcloughlin/geohash)
+[![Build status](https://img.shields.io/travis/mmcloughlin/geohash.svg?style=flat-square)](https://travis-ci.org/mmcloughlin/geohash)
+[![Coverage](https://img.shields.io/coveralls/mmcloughlin/geohash.svg?style=flat-square)](https://coveralls.io/r/mmcloughlin/geohash)
+[![Go Report Card](https://goreportcard.com/badge/github.com/mmcloughlin/geohash?style=flat-square)](https://goreportcard.com/report/github.com/mmcloughlin/geohash)
+
+## Install
+
+Fetch the package with
+
+```
+go get {{ .ImportPath }}
+```
+
+And import it into your programs with
+
+```go
+import "{{ .ImportPath }}"
+```
+
+{{ .EmitUsage }}

--- a/vendor/github.com/mmcloughlin/geohash/asm_x86.s
+++ b/vendor/github.com/mmcloughlin/geohash/asm_x86.s
@@ -1,0 +1,56 @@
+// +build amd64,go1.6
+
+#include "textflag.h"
+
+// func cpuid(eaxArg, ecxArg uint32) (eax, ebx, ecx, edx uint32)
+TEXT ·cpuid(SB), NOSPLIT, $0-24
+	MOVL eaxArg+0(FP), AX
+	MOVL ecxArg+4(FP), CX
+	CPUID
+	MOVL AX, eax+8(FP)
+	MOVL BX, ebx+12(FP)
+	MOVL CX, ecx+16(FP)
+	MOVL DX, edx+20(FP)
+	RET
+
+// func EncodeInt(lat, lng float64) uint64
+TEXT ·EncodeInt(SB), NOSPLIT, $0
+	CMPB ·useAsm(SB), $1
+	JNE  fallback
+
+#define LATF	X0
+#define LATI	R8
+#define LNGF	X1
+#define LNGI	R9
+#define TEMP	R10
+#define GHSH	R11
+#define MASK	BX
+
+	MOVSD lat+0(FP), LATF
+	MOVSD lng+8(FP), LNGF
+
+	MOVQ $0x5555555555555555, MASK
+
+	MULSD $(0.005555555555555556), LATF
+	ADDSD $(1.5), LATF
+
+	MULSD $(0.002777777777777778), LNGF
+	ADDSD $(1.5), LNGF
+
+	MOVQ LNGF, LNGI
+	SHRQ $20, LNGI
+
+	MOVQ  LATF, LATI
+	SHRQ  $20, LATI
+	PDEPQ MASK, LATI, GHSH
+
+	PDEPQ MASK, LNGI, TEMP
+
+	SHLQ $1, TEMP
+	XORQ TEMP, GHSH
+
+	MOVQ GHSH, ret+16(FP)
+	RET
+
+fallback:
+	JMP ·encodeInt(SB)

--- a/vendor/github.com/mmcloughlin/geohash/base32.go
+++ b/vendor/github.com/mmcloughlin/geohash/base32.go
@@ -1,0 +1,44 @@
+package geohash
+
+// encoding encapsulates an encoding defined by a given base32 alphabet.
+type encoding struct {
+	encode string
+	decode [256]byte
+}
+
+// newEncoding constructs a new encoding defined by the given alphabet,
+// which must be a 32-byte string.
+func newEncoding(encoder string) *encoding {
+	e := new(encoding)
+	e.encode = encoder
+	for i := 0; i < len(e.decode); i++ {
+		e.decode[i] = 0xff
+	}
+	for i := 0; i < len(encoder); i++ {
+		e.decode[encoder[i]] = byte(i)
+	}
+	return e
+}
+
+// Decode string into bits of a 64-bit word. The string s may be at most 12
+// characters.
+func (e *encoding) Decode(s string) uint64 {
+	x := uint64(0)
+	for i := 0; i < len(s); i++ {
+		x = (x << 5) | uint64(e.decode[s[i]])
+	}
+	return x
+}
+
+// Encode bits of 64-bit word into a string.
+func (e *encoding) Encode(x uint64) string {
+	b := [12]byte{}
+	for i := 0; i < 12; i++ {
+		b[11-i] = e.encode[x&0x1f]
+		x >>= 5
+	}
+	return string(b[:])
+}
+
+// Base32Encoding with the Geohash alphabet.
+var base32encoding = newEncoding("0123456789bcdefghjkmnpqrstuvwxyz")

--- a/vendor/github.com/mmcloughlin/geohash/geohash.go
+++ b/vendor/github.com/mmcloughlin/geohash/geohash.go
@@ -1,0 +1,292 @@
+// Package geohash provides encoding and decoding of string and integer
+// geohashes.
+package geohash
+
+import (
+	"math"
+)
+
+// Direction represents directions in the latitute/longitude space.
+type Direction int
+
+// Cardinal and intercardinal directions
+const (
+	North Direction = iota
+	NorthEast
+	East
+	SouthEast
+	South
+	SouthWest
+	West
+	NorthWest
+)
+
+// Encode the point (lat, lng) as a string geohash with the standard 12
+// characters of precision.
+func Encode(lat, lng float64) string {
+	return EncodeWithPrecision(lat, lng, 12)
+}
+
+// EncodeWithPrecision encodes the point (lat, lng) as a string geohash with
+// the specified number of characters of precision (max 12).
+func EncodeWithPrecision(lat, lng float64, chars uint) string {
+	bits := 5 * chars
+	inthash := EncodeIntWithPrecision(lat, lng, bits)
+	enc := base32encoding.Encode(inthash)
+	return enc[12-chars:]
+}
+
+// EncodeInt encodes the point (lat, lng) to a 64-bit integer geohash.
+func EncodeInt(lat, lng float64) uint64
+
+// encodeInt provides a Go implementation of integer geohash. This is the
+// default implementation of EncodeInt, but optimized versions are provided
+// for certain architectures.
+func encodeInt(lat, lng float64) uint64 {
+	latInt := encodeRange(lat, 90)
+	lngInt := encodeRange(lng, 180)
+	return interleave(latInt, lngInt)
+}
+
+// EncodeIntWithPrecision encodes the point (lat, lng) to an integer with the
+// specified number of bits.
+func EncodeIntWithPrecision(lat, lng float64, bits uint) uint64 {
+	hash := EncodeInt(lat, lng)
+	return hash >> (64 - bits)
+}
+
+// Box represents a rectangle in latitude/longitude space.
+type Box struct {
+	MinLat float64
+	MaxLat float64
+	MinLng float64
+	MaxLng float64
+}
+
+// Center returns the center of the box.
+func (b Box) Center() (lat, lng float64) {
+	lat = (b.MinLat + b.MaxLat) / 2.0
+	lng = (b.MinLng + b.MaxLng) / 2.0
+	return
+}
+
+// Contains decides whether (lat, lng) is contained in the box. The
+// containment test is inclusive of the edges and corners.
+func (b Box) Contains(lat, lng float64) bool {
+	return (b.MinLat <= lat && lat <= b.MaxLat &&
+		b.MinLng <= lng && lng <= b.MaxLng)
+}
+
+// minDecimalPlaces returns the minimum number of decimal places such that
+// there must exist an number with that many places within any range of width
+// r. This is intended for returning minimal precision coordinates inside a
+// box.
+func maxDecimalPower(r float64) float64 {
+	m := int(math.Floor(math.Log10(r)))
+	return math.Pow10(m)
+}
+
+// Round returns a point inside the box, making an effort to round to minimal
+// precision.
+func (b Box) Round() (lat, lng float64) {
+	x := maxDecimalPower(b.MaxLat - b.MinLat)
+	lat = math.Ceil(b.MinLat/x) * x
+	x = maxDecimalPower(b.MaxLng - b.MinLng)
+	lng = math.Ceil(b.MinLng/x) * x
+	return
+}
+
+// errorWithPrecision returns the error range in latitude and longitude for in
+// integer geohash with bits of precision.
+func errorWithPrecision(bits uint) (latErr, lngErr float64) {
+	b := int(bits)
+	latBits := b / 2
+	lngBits := b - latBits
+	latErr = math.Ldexp(180.0, -latBits)
+	lngErr = math.Ldexp(360.0, -lngBits)
+	return
+}
+
+// BoundingBox returns the region encoded by the given string geohash.
+func BoundingBox(hash string) Box {
+	bits := uint(5 * len(hash))
+	inthash := base32encoding.Decode(hash)
+	return BoundingBoxIntWithPrecision(inthash, bits)
+}
+
+// BoundingBoxIntWithPrecision returns the region encoded by the integer
+// geohash with the specified precision.
+func BoundingBoxIntWithPrecision(hash uint64, bits uint) Box {
+	fullHash := hash << (64 - bits)
+	latInt, lngInt := deinterleave(fullHash)
+	lat := decodeRange(latInt, 90)
+	lng := decodeRange(lngInt, 180)
+	latErr, lngErr := errorWithPrecision(bits)
+	return Box{
+		MinLat: lat,
+		MaxLat: lat + latErr,
+		MinLng: lng,
+		MaxLng: lng + lngErr,
+	}
+}
+
+// BoundingBoxInt returns the region encoded by the given 64-bit integer
+// geohash.
+func BoundingBoxInt(hash uint64) Box {
+	return BoundingBoxIntWithPrecision(hash, 64)
+}
+
+// Decode the string geohash to a (lat, lng) point.
+func Decode(hash string) (lat, lng float64) {
+	box := BoundingBox(hash)
+	return box.Round()
+}
+
+// DecodeCenter decodes the string geohash to the central point of the bounding box.
+func DecodeCenter(hash string) (lat, lng float64) {
+	box := BoundingBox(hash)
+	return box.Center()
+}
+
+// DecodeIntWithPrecision decodes the provided integer geohash with bits of
+// precision to a (lat, lng) point.
+func DecodeIntWithPrecision(hash uint64, bits uint) (lat, lng float64) {
+	box := BoundingBoxIntWithPrecision(hash, bits)
+	return box.Round()
+}
+
+// DecodeInt decodes the provided 64-bit integer geohash to a (lat, lng) point.
+func DecodeInt(hash uint64) (lat, lng float64) {
+	return DecodeIntWithPrecision(hash, 64)
+}
+
+// Neighbors returns a slice of geohash strings that correspond to the provided
+// geohash's neighbors.
+func Neighbors(hash string) []string {
+	box := BoundingBox(hash)
+	lat, lng := box.Center()
+	latDelta := box.MaxLat - box.MinLat
+	lngDelta := box.MaxLng - box.MinLng
+	precision := uint(len(hash))
+	return []string{
+		// N
+		EncodeWithPrecision(lat+latDelta, lng, precision),
+		// NE,
+		EncodeWithPrecision(lat+latDelta, lng+lngDelta, precision),
+		// E,
+		EncodeWithPrecision(lat, lng+lngDelta, precision),
+		// SE,
+		EncodeWithPrecision(lat-latDelta, lng+lngDelta, precision),
+		// S,
+		EncodeWithPrecision(lat-latDelta, lng, precision),
+		// SW,
+		EncodeWithPrecision(lat-latDelta, lng-lngDelta, precision),
+		// W,
+		EncodeWithPrecision(lat, lng-lngDelta, precision),
+		// NW
+		EncodeWithPrecision(lat+latDelta, lng-lngDelta, precision),
+	}
+}
+
+// NeighborsInt returns a slice of uint64s that correspond to the provided hash's
+// neighbors at 64-bit precision.
+func NeighborsInt(hash uint64) []uint64 {
+	return NeighborsIntWithPrecision(hash, 64)
+}
+
+// NeighborsIntWithPrecision returns a slice of uint64s that correspond to the
+// provided hash's neighbors at the given precision.
+func NeighborsIntWithPrecision(hash uint64, bits uint) []uint64 {
+	box := BoundingBoxIntWithPrecision(hash, bits)
+	lat, lng := box.Center()
+	latDelta := box.MaxLat - box.MinLat
+	lngDelta := box.MaxLng - box.MinLng
+	return []uint64{
+		// N
+		EncodeIntWithPrecision(lat+latDelta, lng, bits),
+		// NE,
+		EncodeIntWithPrecision(lat+latDelta, lng+lngDelta, bits),
+		// E,
+		EncodeIntWithPrecision(lat, lng+lngDelta, bits),
+		// SE,
+		EncodeIntWithPrecision(lat-latDelta, lng+lngDelta, bits),
+		// S,
+		EncodeIntWithPrecision(lat-latDelta, lng, bits),
+		// SW,
+		EncodeIntWithPrecision(lat-latDelta, lng-lngDelta, bits),
+		// W,
+		EncodeIntWithPrecision(lat, lng-lngDelta, bits),
+		// NW
+		EncodeIntWithPrecision(lat+latDelta, lng-lngDelta, bits),
+	}
+}
+
+// Neighbor returns a geohash string that corresponds to the provided 
+// geohash's neighbor in the provided direction
+func Neighbor(hash string, direction Direction) string {
+	return Neighbors(hash)[direction]
+}
+
+// NeighborInt returns a uint64 that corresponds to the provided hash's
+// neighbor in the provided direction at 64-bit precision.
+func NeighborInt(hash uint64, direction Direction) uint64 {
+	return NeighborsIntWithPrecision(hash, 64)[direction]
+}
+
+// NeighborIntWithPrecision returns a uint64s that corresponds to the
+// provided hash's neighbor in the provided direction at the given precision.
+func NeighborIntWithPrecision(hash uint64, bits uint, direction Direction) uint64 {
+	return NeighborsIntWithPrecision(hash, bits)[direction]
+}
+
+// precalculated for performance
+var exp232 = math.Exp2(32)
+
+// Encode the position of x within the range -r to +r as a 32-bit integer.
+func encodeRange(x, r float64) uint32 {
+	p := (x + r) / (2 * r)
+	return uint32(p * exp232)
+}
+
+// Decode the 32-bit range encoding X back to a value in the range -r to +r.
+func decodeRange(X uint32, r float64) float64 {
+	p := float64(X) / exp232
+	x := 2*r*p - r
+	return x
+}
+
+// Spread out the 32 bits of x into 64 bits, where the bits of x occupy even
+// bit positions.
+func spread(x uint32) uint64 {
+	X := uint64(x)
+	X = (X | (X << 16)) & 0x0000ffff0000ffff
+	X = (X | (X << 8)) & 0x00ff00ff00ff00ff
+	X = (X | (X << 4)) & 0x0f0f0f0f0f0f0f0f
+	X = (X | (X << 2)) & 0x3333333333333333
+	X = (X | (X << 1)) & 0x5555555555555555
+	return X
+}
+
+// Interleave the bits of x and y. In the result, x and y occupy even and odd
+// bitlevels, respectively.
+func interleave(x, y uint32) uint64 {
+	return spread(x) | (spread(y) << 1)
+}
+
+// Squash the even bitlevels of X into a 32-bit word. Odd bitlevels of X are
+// ignored, and may take any value.
+func squash(X uint64) uint32 {
+	X &= 0x5555555555555555
+	X = (X | (X >> 1)) & 0x3333333333333333
+	X = (X | (X >> 2)) & 0x0f0f0f0f0f0f0f0f
+	X = (X | (X >> 4)) & 0x00ff00ff00ff00ff
+	X = (X | (X >> 8)) & 0x0000ffff0000ffff
+	X = (X | (X >> 16)) & 0x00000000ffffffff
+	return uint32(X)
+}
+
+// Deinterleave the bits of X into 32-bit words containing the even and odd
+// bitlevels of X, respectively.
+func deinterleave(X uint64) (uint32, uint32) {
+	return squash(X), squash(X >> 1)
+}

--- a/vendor/github.com/mmcloughlin/geohash/geohash_x86.go
+++ b/vendor/github.com/mmcloughlin/geohash/geohash_x86.go
@@ -1,0 +1,24 @@
+// +build amd64,go1.6
+
+package geohash
+
+// useAsm flag determines whether the assembly version of EncodeInt will be
+// used. By Default we fall back to encodeInt.
+var useAsm bool
+
+// cpuid executes the CPUID instruction to obtain processor identification and
+// feature information.
+func cpuid(eaxArg, ecxArg uint32) (eax, ebx, ecx, edx uint32)
+
+// hasBMI2 returns whether the CPU supports Bit Manipulation Instruction Set
+// 2.
+func hasBMI2() bool {
+	_, ebx, _, _ := cpuid(7, 0)
+	return ebx&(1<<8) != 0
+}
+
+// init determines whether to use assembly version by performing CPU feature
+// check.
+func init() {
+	useAsm = hasBMI2()
+}

--- a/vendor/github.com/mmcloughlin/geohash/go.mod
+++ b/vendor/github.com/mmcloughlin/geohash/go.mod
@@ -1,0 +1,1 @@
+module github.com/mmcloughlin/geohash

--- a/vendor/github.com/mmcloughlin/geohash/stubs.s
+++ b/vendor/github.com/mmcloughlin/geohash/stubs.s
@@ -1,0 +1,7 @@
+// +build !amd64 !go1.6
+
+// Define NOSPLIT ourselves since "textflag.h" is missing in old Go versions.
+#define NOSPLIT	4
+
+TEXT ·EncodeInt(SB), NOSPLIT, $0
+	JMP ·encodeInt(SB)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,6 +15,8 @@ github.com/golang/protobuf/proto
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
+# github.com/mmcloughlin/geohash v0.9.0
+github.com/mmcloughlin/geohash
 # github.com/prometheus/client_golang v1.2.1
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal


### PR DESCRIPTION
Hi @lukasmalkmus,

I added the following labels:
* geohash
* address
* city
* brand

With the geohash label you can create quite (imho) cool worldmap panels in Grafana
![grafana-screenshot-worldmap](https://user-images.githubusercontent.com/13837847/76501532-b70e2c80-6442-11ea-9452-a456542dacb4.png)

With the address / city / brand label you can see more clearly which gas station in the city is displayed
![Bildschirmfoto 2020-03-12 um 09 23 08](https://user-images.githubusercontent.com/13837847/76501872-59c6ab00-6443-11ea-9259-75642d7fcd2c.png)

There are some string manipulations in the code now because sometimes the city names are in full caps, streets are with trailing whitespaces and other really annoying stuff.

Please let me know what you think and if there's something you would want me to improve codewise. Still kinda new to go :)



cheers!
